### PR TITLE
fix: crash when `devDependencies` undefined using `ts-standard`

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -354,7 +354,7 @@ async function resolveSettings (
           } else if (pkg?.devDependencies?.standardx != null) {
             linter = 'standardx'
             linterName = 'JavaScript Standard Style with custom tweaks'
-          } else if (pkg?.devDependencies['ts-standard'] != null) {
+          } else if (pkg?.devDependencies?.['ts-standard'] != null) {
             linter = 'ts-standard'
             linterName = 'TypeScript Standard Style'
           }
@@ -363,7 +363,7 @@ async function resolveSettings (
             pkg?.devDependencies?.standard != null ||
             pkg?.devDependencies?.semistandard != null ||
             pkg?.devDependencies?.standardx != null ||
-            pkg?.devDependencies['ts-standard'] != null
+            pkg?.devDependencies?.['ts-standard'] != null
           ) {
             if (pkg[linter] != null) {
               // if [linter] presented in package.json combine the global one.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[✅ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

### Problem
 - If a `package.json` file does not have a `devDependencies` property, the plugin explodes.
 - Example output when things go bad:
 ```
[Info  - 7:52:50 PM] JavaScript Standard Style server stopped.
[Info  - 7:52:51 PM] JavaScript Standard Style server is running.
(node:7171) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'ts-standard' of undefined
    at /Users/flet/.vscode/extensions/standard.vscode-standard-2.0.0/server/out/server.js:179:84
(Use `Code Helper (Renderer) --trace-warnings ...` to show where the warning was created)
(node:7171) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:7171) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:7171) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'ts-standard' of undefined
    at /Users/flet/.vscode/extensions/standard.vscode-standard-2.0.0/server/out/server.js:179:84
(node:7171) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
```

### Fix
 - Added optional chaining operator `?.` to avoid exploding when checking for `ts-standard` in devDependencies

**Which issue (if any) does this pull request address?**
 - I did not see any related open issues.

**Is there anything you'd like reviewers to focus on?**
 - No